### PR TITLE
Lazy load snacks

### DIFF
--- a/after/plugin/snacks.lua
+++ b/after/plugin/snacks.lua
@@ -1,24 +1,26 @@
-local snacks = require('snacks')
-snacks.setup({
-    config = {
-        priority = 1000,
-        lazy = false,
-        opts = {
-            bigfile = { enabled = true },
-            dashboard = { enabled = true },
-            explorer = { enabled = true },
-            indent = { enabled = true },
-            input = { enabled = true },
-            notifier = {
-                enabled = true,
-                timeout = 3000,
+local ok, snacks = pcall(require, 'snacks')
+if ok then
+    snacks.setup({
+        config = {
+            priority = 1000,
+            lazy = false,
+            opts = {
+                bigfile = { enabled = true },
+                dashboard = { enabled = true },
+                explorer = { enabled = true },
+                indent = { enabled = true },
+                input = { enabled = true },
+                notifier = {
+                    enabled = true,
+                    timeout = 3000,
+                },
+                picker = { enabled = true },
+                quickfile = { enabled = true },
+                scope = { enabled = true },
+                scroll = { enabled = true },
+                statuscolumn = { enabled = true },
+                words = { enabled = true },
             },
-            picker = { enabled = true },
-            quickfile = { enabled = true },
-            scope = { enabled = true },
-            scroll = { enabled = true },
-            statuscolumn = { enabled = true },
-            words = { enabled = true },
-        },
-    }
-})
+        }
+    })
+end

--- a/lua/diesi/packer.lua
+++ b/lua/diesi/packer.lua
@@ -115,7 +115,39 @@ return require('packer').startup(function(use)
     use({
         "mikavilpas/yazi.nvim",
         requires = {
-            { "folke/snacks.nvim" },
+            {
+                "folke/snacks.nvim",
+                opt = true,
+                cmd = "Snacks",
+                config = function()
+                    local ok, snacks = pcall(require, "snacks")
+                    if ok then
+                        snacks.setup({
+                            config = {
+                                priority = 1000,
+                                lazy = false,
+                                opts = {
+                                    bigfile = { enabled = true },
+                                    dashboard = { enabled = true },
+                                    explorer = { enabled = true },
+                                    indent = { enabled = true },
+                                    input = { enabled = true },
+                                    notifier = {
+                                        enabled = true,
+                                        timeout = 3000,
+                                    },
+                                    picker = { enabled = true },
+                                    quickfile = { enabled = true },
+                                    scope = { enabled = true },
+                                    scroll = { enabled = true },
+                                    statuscolumn = { enabled = true },
+                                    words = { enabled = true },
+                                },
+                            },
+                        })
+                    end
+                end,
+            },
         },
         config = function()
             require("yazi").setup()

--- a/lua/diesi/remap.lua
+++ b/lua/diesi/remap.lua
@@ -32,6 +32,9 @@ vim.keymap.set({'n', 'x', 'o'}, 'S', '<cmd>HopLine<cr>', { noremap = true, silen
 
 vim.keymap.set({'n', 'x', 'o'}, '<leader>gB', ':lua Snacks.gitbrowse()<cr>', { noremap = true, silent = true })
 vim.keymap.set({'n', 'x', 'o'}, '<leader>cH', ':lua Snacks.picker.command_history()<cr>', { noremap = true, silent = true })
-vim.keymap.set({'n', 'x', 'o'}, '<leader>b', ':lua Snacks.picker.buffers()<cr>', { noremap = true, silent = true })
+vim.keymap.set({'n', 'x', 'o'}, '<leader>b', function()
+    require('packer').loader('snacks.nvim')
+    require('snacks').picker.buffers()
+end, { noremap = true, silent = true })
 
 


### PR DESCRIPTION
## Summary
- use packer to lazy load snacks.nvim when yazi.nvim is loaded
- guard snacks setup so it only runs when the plugin is available
- load snacks before `<leader>b` mapping uses it

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_683b389941cc8320a8ffc51287334ec6