### PR TITLE
Enable emmet on blade templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains my personal **Neovim** configuration powered by `packer
 - **hlargs** highlighting function arguments.
 - **agrolens.nvim** for navigating functions.
 - **nvim-macros** storing macros in `macros.json`.
-- **nvim-emmet** wrapper around Emmet.
+- **nvim-emmet** wrapper around Emmet with Blade template support.
 - **CHADTree** and **nvim-tree** file browsers (optional).
 - **Yazi** file manager integration with key mappings to toggle.
 - **grug-far.nvim** for project wide search and replace.
@@ -70,6 +70,7 @@ Below is an overview of the custom shortcuts defined throughout this configurati
   - `-` toggles the file manager and `_` opens it in the current path.
 - **Emmet**
   - `leader+e` wraps the current selection with an abbreviation.
+  - Works in `*.blade.php` templates.
 - **Git and Undo**
   - `leader+gs` opens **Fugitive** and `leader+u` toggles **UndoTree**.
 - **Debugging (DAP)**

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -10,7 +10,15 @@ lspconfig.tailwindcss.setup {}
 
 -- lspconfig.phpactor.setup {}
 lspconfig.intelephense.setup {}
-lspconfig.emmet_language_server.setup {}
+lspconfig.emmet_language_server.setup {
+  filetypes = {
+    'html',
+    'css',
+    'blade',
+    'typescriptreact',
+    'javascriptreact',
+  },
+}
 lspconfig.ast_grep.setup {}
 lspconfig.gopls.setup{}
 


### PR DESCRIPTION
## Summary
- support `blade` filetype for emmet language server
- document blade support in README

## Testing
- `nvim --headless --noplugin -u NONE -c "luafile after/plugin/lsp.lua" -c "quit"` *(fails: nvim not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68403f1c61d48320a76db036c5f5c159