### PR TITLE
Improve recent files search

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Below is an overview of the custom shortcuts defined throughout this configurati
   - `leader+fd` search files in a chosen directory and `leader+fc` grep for a string.
   - `leader+fe` resume last picker and `leader+fif` run live grep with args.
   - `leader+fs` search visual selection and `leader+fw` search the word under cursor.
-  - `leader+fr` recent files, `leader+fof` function search and `leader+faf` search functions in all buffers.
+  - `leader+fr` open recent files ordered by last usage, `leader+fof` function search and `leader+faf` search functions in all buffers.
   - `leader+ss` pick a search directory and `leader+sg` grep inside it.
 - **Yazi**
   - `-` toggles the file manager and `_` opens it in the current path.

--- a/after/plugin/telescope.lua
+++ b/after/plugin/telescope.lua
@@ -22,9 +22,9 @@ local live_grep_args_shortcuts = require("telescope-live-grep-args.shortcuts")
 vim.keymap.set({"v", "n"}, "<leader>fs", live_grep_args_shortcuts.grep_visual_selection)
 vim.keymap.set({"v", "n"}, "<leader>fw", live_grep_args_shortcuts.grep_word_under_cursor)
 
-vim.api.nvim_set_keymap("n", "<Leader>fr",
-    [[<cmd>lua require('telescope').extensions.recent_files.pick()<CR>]],
-    {noremap = true, silent = true})
+vim.keymap.set("n", "<leader>fr", function()
+    require('diesi.recent').open()
+end, { noremap = true, silent = true })
 
 vim.keymap.set("n", "<leader>fof", ":Telescope agrolens query=functions<CR>")
 vim.keymap.set("n", "<leader>faf", ":Telescope agrolens query=functions buffers=all<CR>")
@@ -137,9 +137,6 @@ require('telescope').setup {
         }
     },
     extensions = {
-        recent_files = {
-            only_cwd = true,
-        },
         agrolens = {
             debug = false,
             same_type = true,
@@ -149,8 +146,6 @@ require('telescope').setup {
         }
     }
 }
-
-require("telescope").load_extension("recent_files")
 require("telescope").load_extension("dap")
 require("telescope").load_extension("live_grep_args")
 require("telescope").load_extension("refactoring")

--- a/lua/diesi/init.lua
+++ b/lua/diesi/init.lua
@@ -3,6 +3,7 @@ require('diesi.commands')
 require('diesi.clipboard')
 require('diesi.folds')
 require('diesi.typoscript')
+require('diesi.recent').setup()
 
 vim.opt.number = true
 vim.wo.relativenumber = true

--- a/lua/diesi/packer.lua
+++ b/lua/diesi/packer.lua
@@ -38,7 +38,6 @@ return require('packer').startup(function(use)
     }
     use({"ray-x/web-tools.nvim"})
 
-    use({"smartpde/telescope-recent-files"})
 
     use ({"nvim-tree/nvim-web-devicons"})
     use ({"lewis6991/gitsigns.nvim"})

--- a/lua/diesi/recent.lua
+++ b/lua/diesi/recent.lua
@@ -1,0 +1,90 @@
+local M = {}
+
+local data_path = vim.fn.stdpath('data') .. '/recent_files.json'
+local max_items = 100
+
+local function load()
+  local f = io.open(data_path, 'r')
+  if not f then
+    return {}
+  end
+  local ok, decoded = pcall(vim.fn.json_decode, f:read('*a'))
+  f:close()
+  if ok and type(decoded) == 'table' then
+    return decoded
+  end
+  return {}
+end
+
+local function save(list)
+  local f = io.open(data_path, 'w')
+  if not f then
+    return
+  end
+  f:write(vim.fn.json_encode(list))
+  f:close()
+end
+
+function M.update(filepath)
+  local list = load()
+  -- remove existing entry
+  for i, item in ipairs(list) do
+    if item.file == filepath then
+      table.remove(list, i)
+      break
+    end
+  end
+  table.insert(list, 1, { file = filepath, time = os.time() })
+  -- trim list
+  while #list > max_items do
+    table.remove(list)
+  end
+  save(list)
+end
+
+function M.open()
+  local list = load()
+  table.sort(list, function(a, b)
+    return (a.time or 0) > (b.time or 0)
+  end)
+
+  local results = {}
+  for _, item in ipairs(list) do
+    table.insert(results, item.file)
+  end
+
+  local pickers = require('telescope.pickers')
+  local finders = require('telescope.finders')
+  local conf = require('telescope.config').values
+  local actions = require('telescope.actions')
+  local action_state = require('telescope.actions.state')
+
+  pickers.new({}, {
+    prompt_title = 'Recent Files',
+    finder = finders.new_table({ results = results }),
+    sorter = conf.generic_sorter({}),
+    attach_mappings = function(prompt_bufnr, _)
+      actions.select_default:replace(function()
+        local selection = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        if selection and selection[1] then
+          vim.cmd('edit ' .. vim.fn.fnameescape(selection[1]))
+        end
+      end)
+      return true
+    end,
+  }):find()
+end
+
+function M.setup()
+  vim.api.nvim_create_autocmd('BufReadPost', {
+    callback = function()
+      local file = vim.fn.expand('%:p')
+      if file ~= '' then
+        M.update(file)
+      end
+    end,
+  })
+end
+
+return M


### PR DESCRIPTION
## Summary
- add new module `diesi.recent` to track recent files persistently and present them via Telescope
- map `<leader>fr` to use this new picker
- remove old telescope-recent-files plugin reference
- document behaviour in README

## Testing
- `git status --short`
- `nvim` was not available so unable to run runtime tests

------
https://chatgpt.com/codex/tasks/task_b_68417c3fd4908320ae9dae3ec5ab1bae